### PR TITLE
Avoid name mangling of Fortran symbol.

### DIFF
--- a/ffunc.f90
+++ b/ffunc.f90
@@ -13,9 +13,9 @@
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-     FUNCTION FRTFUNC(STR) BIND(C, name='frtfunc')
+     FUNCTION FORTRANFUNC(STR) BIND(C, name='fortranfunc')
 
-     REAL FRTFUNC
+     REAL FORTRANFUNC
      CHARACTER*(*) STR
 
        STR = 'This line is created in FORTRAN.'

--- a/ffunc.f90
+++ b/ffunc.f90
@@ -13,7 +13,7 @@
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-     FUNCTION FRTFUNC(STR)
+     FUNCTION FRTFUNC(STR) BIND(C, name='frtfunc')
 
      REAL FRTFUNC
      CHARACTER*(*) STR

--- a/ffunc.f90
+++ b/ffunc.f90
@@ -13,10 +13,15 @@
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-     FUNCTION FORTRANFUNC(STR) BIND(C, name='fortranfunc')
+function fortranfunc() result(msg_ptr) bind(c, name='fortranfunc')
+  use, intrinsic :: iso_c_binding, only: &
+       c_ptr, c_char, C_CHAR, C_NEW_LINE, C_NULL_CHAR, c_loc
+  type(c_ptr) :: msg_ptr
+  ! NOTE: `save` is necessary here to make sure that the pointer
+  !       continues to point to valid memory.
+  character(kind=c_char, len=34), target, save :: msg
 
-     REAL FORTRANFUNC
-     CHARACTER*(*) STR
+  msg = C_CHAR_"This line is created in Fortran."//C_NEW_LINE//C_NULL_CHAR
+  msg_ptr = c_loc(msg)
 
-       STR = 'This line is created in FORTRAN.'
-       END
+end function fortranfunc

--- a/polysnake.c
+++ b/polysnake.c
@@ -18,7 +18,7 @@
 #include<Python.h>
 #include<string.h>
 
-double frtfunc_(char *buf, int len_buf);
+double fortranfunc(char *buf, int len_buf);
 const char* cppfunc();
 const char* rustfunc();
 
@@ -26,7 +26,7 @@ static PyObject* generate(PyObject *self, PyObject *args) {
     char mainbuf[1024] = "Combining many languages in one shared module is simple.\n\n";
     char fstore[80];
     int i=0;
-    frtfunc_(fstore, 80);
+    fortranfunc(fstore, 80);
     /* FORTRAN does not null terminate strings. */
     while(fstore[i] != '.') {
         i++;

--- a/polysnake.c
+++ b/polysnake.c
@@ -18,23 +18,14 @@
 #include<Python.h>
 #include<string.h>
 
-double fortranfunc(char *buf, int len_buf);
+const char* fortranfunc();
 const char* cppfunc();
 const char* rustfunc();
 
 static PyObject* generate(PyObject *self, PyObject *args) {
     char mainbuf[1024] = "Combining many languages in one shared module is simple.\n\n";
-    char fstore[80];
-    int i=0;
-    fortranfunc(fstore, 80);
-    /* FORTRAN does not null terminate strings. */
-    while(fstore[i] != '.') {
-        i++;
-    }
-    fstore[i+1] = '\n';
-    fstore[i+2] = '\0';
     strcat(mainbuf, "This line is created in C.\n");
-    strcat(mainbuf, fstore);
+    strcat(mainbuf, fortranfunc());
     strcat(mainbuf, cppfunc());
     strcat(mainbuf, rustfunc());
     return Py_BuildValue("y", mainbuf);


### PR DESCRIPTION
I'm making this change from the web UI for convenience. If you think it's a worthwhile change, I can track down all of the uses of the mangled `frtfunc_` and update them.